### PR TITLE
Setup local development environment with Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,28 @@ This repository contains the source code and configurations for my personal webs
 - **Deployment (in separate repository):**
   - Uses Terraform for provisioning Azure Kubernetes Service (AKS) clusters.
   - Kubernetes manifests manage the deployment of services.
+
+## Local Development Environment Setup
+
+### Prerequisites
+
+- Docker
+- Docker Compose
+
+### Steps to Build and Run the Containers Locally
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/Humancannonball/PersonalSite.git
+   cd PersonalSite
+   ```
+
+2. Build and start the containers using Docker Compose:
+   ```sh
+   docker-compose up --build
+   ```
+
+3. Access the services:
+   - Web frontend: `http://localhost:8080`
+   - Prisoner service: `http://localhost:5000`
+   - Turing service: `http://localhost:5001`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  web:
+    build: ./web
+    ports:
+      - "8080:8080"
+
+  prisoner-service:
+    build: ./prisoner-service
+    ports:
+      - "5000:5000"
+
+  turing-service:
+    build: ./turing-service
+    ports:
+      - "5001:5001"


### PR DESCRIPTION
Add a local development environment setup using Docker Compose.

* **docker-compose.yml**:
  - Define services for `web`, `prisoner-service`, and `turing-service`.
  - Set up the `web` service to build from the `web` directory and expose port 8080.
  - Set up the `prisoner-service` to build from the `prisoner-service` directory and expose port 5000.
  - Set up the `turing-service` to build from the `turing-service` directory and expose port 5001.

* **README.md**:
  - Add instructions for setting up the local development environment using Docker Compose.
  - Include steps to build and run the containers locally.
  - Provide access URLs for the services.

